### PR TITLE
Improve edge to edge implementation

### DIFF
--- a/app/src/androidTest/java/com/spundev/dynamicthemeexport/ui/export/DisplayCornerAwareShapeTest.kt
+++ b/app/src/androidTest/java/com/spundev/dynamicthemeexport/ui/export/DisplayCornerAwareShapeTest.kt
@@ -1,0 +1,223 @@
+package com.spundev.dynamicthemeexport.ui.export
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.spundev.dynamicthemeexport.util.DisplayCorners
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+class DisplayCornerAwareShapeTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun whenPaddingClearsRadius_returnsNull() {
+        // Prepare parameters
+        val displayCorners = DisplayCorners(
+            topStart = 48.dp,
+            topEnd = 48.dp,
+            bottomEnd = 48.dp,
+            bottomStart = 48.dp,
+        )
+        val windowInsets = WindowInsets()
+        val contentPadding = PaddingValues(bottom = 56.dp)
+        val baseShape = RoundedCornerShape(8.dp)
+
+        var result: BoxShapeAndPadding? = null
+        composeTestRule.setContent {
+            result = rememberDisplayCornerAwareShape(
+                displayCorners = displayCorners,
+                contentPadding = contentPadding,
+                windowInsets = windowInsets,
+                baseShape = baseShape
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        assertNull(result)
+    }
+
+    @Test
+    fun whenInsetClearsRadius_returnsNull() {
+        // Prepare parameters
+        val displayCorners = DisplayCorners(
+            topStart = 48.dp,
+            topEnd = 48.dp,
+            bottomEnd = 48.dp,
+            bottomStart = 48.dp,
+        )
+        val windowInsets = WindowInsets(bottom = 56.dp)
+        val contentPadding = PaddingValues.Zero
+        val baseShape = RoundedCornerShape(8.dp)
+
+        var result: BoxShapeAndPadding? = null
+        composeTestRule.setContent {
+            result = rememberDisplayCornerAwareShape(
+                displayCorners = displayCorners,
+                contentPadding = contentPadding,
+                windowInsets = windowInsets,
+                baseShape = baseShape
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        assertNull(result)
+    }
+
+    @Test
+    fun whenInsetPlusPaddingClearsRadius_returnsNull() {
+        // Prepare parameters
+        val displayCorners = DisplayCorners(
+            topStart = 48.dp,
+            topEnd = 48.dp,
+            bottomEnd = 48.dp,
+            bottomStart = 48.dp,
+        )
+        val windowInsets = WindowInsets(bottom = 24.dp)
+        val contentPadding = PaddingValues(bottom = 24.dp)
+        val baseShape = RoundedCornerShape(8.dp)
+
+        var result: BoxShapeAndPadding? = null
+        composeTestRule.setContent {
+            result = rememberDisplayCornerAwareShape(
+                displayCorners = displayCorners,
+                contentPadding = contentPadding,
+                windowInsets = windowInsets,
+                baseShape = baseShape
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        assertNull(result)
+    }
+
+    @Test
+    fun whenPaddingDoesNotClearRadius_returnsShape() {
+        // Prepare parameters
+        val displayCorners = DisplayCorners(
+            topStart = 48.dp,
+            topEnd = 48.dp,
+            bottomEnd = 48.dp,
+            bottomStart = 48.dp,
+        )
+        val windowInsets = WindowInsets(bottom = 24.dp)
+        val contentPadding = PaddingValues(all = 8.dp)
+        val baseShape = RoundedCornerShape(8.dp)
+
+        var result: BoxShapeAndPadding? = null
+        composeTestRule.setContent {
+            result = rememberDisplayCornerAwareShape(
+                displayCorners = displayCorners,
+                contentPadding = contentPadding,
+                windowInsets = windowInsets,
+                baseShape = baseShape
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        assertNotNull(result)
+        assertEquals(
+            RoundedCornerShape(
+                topStart = 8.dp,
+                topEnd = 8.dp,
+                bottomEnd = 48.dp,
+                bottomStart = 48.dp
+            ),
+            result?.shape
+        )
+    }
+
+    @Test
+    fun whenOnlyOneCornerSpecified_returnsShapeForCorner() {
+        // Prepare parameters
+        val displayCorners = DisplayCorners(
+            topStart = 48.dp,
+            topEnd = 48.dp,
+            bottomEnd = Dp.Unspecified,
+            bottomStart = 48.dp,
+        )
+        val windowInsets = WindowInsets(bottom = 24.dp)
+        val contentPadding = PaddingValues(all = 8.dp)
+        val baseShape = RoundedCornerShape(8.dp)
+
+        var result: BoxShapeAndPadding? = null
+        composeTestRule.setContent {
+            result = rememberDisplayCornerAwareShape(
+                displayCorners = displayCorners,
+                contentPadding = contentPadding,
+                windowInsets = windowInsets,
+                baseShape = baseShape
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        assertNotNull(result)
+        assertEquals(
+            RoundedCornerShape(
+                topStart = 8.dp,
+                topEnd = 8.dp,
+                // This was Unspecified, get radius from base shape
+                bottomEnd = 8.dp,
+                bottomStart = 48.dp
+            ),
+            result?.shape
+        )
+    }
+
+    @Test
+    fun whenNoBottomCornersSpecified_returnsNull() {
+        // Prepare parameters
+        val displayCorners = DisplayCorners(
+            topStart = 48.dp,
+            topEnd = 48.dp,
+            bottomEnd = Dp.Unspecified,
+            bottomStart = Dp.Unspecified,
+        )
+        val windowInsets = WindowInsets(bottom = 24.dp)
+        val contentPadding = PaddingValues(all = 8.dp)
+        val baseShape = RoundedCornerShape(8.dp)
+
+        var result: BoxShapeAndPadding? = null
+        composeTestRule.setContent {
+            result = rememberDisplayCornerAwareShape(
+                displayCorners = displayCorners,
+                contentPadding = contentPadding,
+                windowInsets = windowInsets,
+                baseShape = baseShape
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        assertNull(result)
+    }
+
+    @Test
+    fun whenNoCornersSpecified_returnsNull() {
+        // Prepare parameters
+        val displayCorners = DisplayCorners.Unspecified
+        val windowInsets = WindowInsets(bottom = 24.dp)
+        val contentPadding = PaddingValues(all = 8.dp)
+        val baseShape = RoundedCornerShape(8.dp)
+
+        var result: BoxShapeAndPadding? = null
+        composeTestRule.setContent {
+            result = rememberDisplayCornerAwareShape(
+                displayCorners = displayCorners,
+                contentPadding = contentPadding,
+                windowInsets = windowInsets,
+                baseShape = baseShape
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        assertNull(result)
+    }
+}

--- a/app/src/main/java/com/spundev/dynamicthemeexport/data/ThemeColorPack.kt
+++ b/app/src/main/java/com/spundev/dynamicthemeexport/data/ThemeColorPack.kt
@@ -37,7 +37,7 @@ data class ThemeColorPack(
             darkColorScheme.toColorStringMap(colorFormat).forEach { (key, value) ->
                 appendLine("    $key = $value,")
             }
-            appendLine(")")
+            append(")")
         }
     }
 

--- a/app/src/main/java/com/spundev/dynamicthemeexport/ui/MainScreen.kt
+++ b/app/src/main/java/com/spundev/dynamicthemeexport/ui/MainScreen.kt
@@ -4,11 +4,15 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -40,8 +44,7 @@ fun MainScreen(
     onDarkThemeChange: (isDarkTheme: Boolean) -> Unit,
 ) {
     Surface(modifier = Modifier.fillMaxSize()) {
-        Column(modifier = Modifier.systemBarsPadding()) {
-
+        Column {
             var currentScreenIndex by rememberSaveable { mutableIntStateOf(0) }
             MainTopBar(
                 isDarkTheme = isDarkTheme,
@@ -73,10 +76,14 @@ private fun MainTopBar(
     onCurrentScreenChange: (index: Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val topBarInset = WindowInsets.safeDrawing.only(
+        WindowInsetsSides.Horizontal + WindowInsetsSides.Top
+    )
+
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
+        modifier = modifier.windowInsetsPadding(topBarInset)
     ) {
         ScreenContentSelector(
             currentScreenIndex = currentScreenIndex,

--- a/app/src/main/java/com/spundev/dynamicthemeexport/ui/export/DisplayCornerAwareShape.kt
+++ b/app/src/main/java/com/spundev/dynamicthemeexport/ui/export/DisplayCornerAwareShape.kt
@@ -1,0 +1,106 @@
+package com.spundev.dynamicthemeexport.ui.export
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
+import com.spundev.dynamicthemeexport.util.DisplayCorners
+
+/**
+ * The [Shape] and inner bottom padding to apply to a box so its content isn't clipped by the
+ * display's bottom corners.
+ */
+internal data class BoxShapeAndPadding(
+    val shape: Shape,
+    val innerBottomPadding: Dp,
+)
+
+/**
+ * Calculates the [Shape] for the code viewer that avoids clipping content under the bottom
+ * display corners.
+ * This will adjust the bottom corners to fit the screen corners, but only when the bottom inset +
+ * padding isn't enough to clear them naturally.
+ * @return A [BoxShapeAndPadding] with the values required to create a Box that avoids the device's
+ * corners, or `null` if there is no need to add a special shape to avoid them. A `null` value means
+ * that the device's corners are not rounded, or that insets + padding already clears the corners.
+ */
+@Composable
+internal fun rememberDisplayCornerAwareShape(
+    displayCorners: DisplayCorners,
+    contentPadding: PaddingValues,
+    windowInsets: WindowInsets,
+    baseShape: CornerBasedShape = MaterialTheme.shapes.small
+): BoxShapeAndPadding? {
+    val density = LocalDensity.current
+
+    // If the sum of bottom inset and bottom padding is higher than the biggest bottom corner
+    // radius, we don't need to adjust our shape to prevent the content from getting cut off.
+    val paddingPlusInsetClearsRadius by remember(
+        displayCorners,
+        density,
+        contentPadding,
+        windowInsets
+    ) {
+        // Inset values should not be read during composition and the only recommended way is to use
+        // the dedicated Modifier that will not cause recomposition when values change.
+        // Since we really need to know if the available bottom inset we are going to apply (plus
+        // the padding) will clear the device's display corners, we are using derivedStateOf to
+        // limit recompositions.
+        derivedStateOf {
+            // Get the biggest radius from the bottom corners.
+            val displayBottomStart = displayCorners.bottomStart
+            val displayBottomEnd = displayCorners.bottomEnd
+            // Make sure to not use maxOf with Dp.Unspecified
+            val startRadius = if (displayBottomStart.isSpecified) displayBottomStart else 0.dp
+            val endRadius = if (displayBottomEnd.isSpecified) displayBottomEnd else 0.dp
+            val maxDisplayBottomRadius = maxOf(startRadius, endRadius)
+
+            // Also get the bottom inset we are going to apply in Dp.
+            val bottomInsetDp = with(density) { windowInsets.getBottom(density).toDp() }
+
+            // Check if the sum of our bottom inset and padding is higher than the biggest corner.
+            (bottomInsetDp + contentPadding.calculateBottomPadding()) >= maxDisplayBottomRadius
+        }
+    }
+
+    // Calculate the shape of the Box.
+    return remember(
+        displayCorners,
+        paddingPlusInsetClearsRadius,
+        baseShape
+    ) {
+        // Check if the spacing we are going to apply to the Box is big enough to clear the corners.
+        // - If it is big enough, we don't need to change its shape, since it will never get cut by
+        //   any corner.
+        // - If it is not big enough, our box might be cut by the corners. To avoid this, we will
+        //   make our box the same shape as the device display.
+        val displayBottomStart = displayCorners.bottomStart
+        val displayBottomEnd = displayCorners.bottomEnd
+        if (!paddingPlusInsetClearsRadius && (displayBottomStart.isSpecified || displayBottomEnd.isSpecified)) {
+            // Make sure to not create a CornerSize or use maxOf with Dp.Unspecified
+            val startRadius = if (displayBottomStart.isSpecified) displayBottomStart else null
+            val endRadius = if (displayBottomEnd.isSpecified) displayBottomEnd else null
+            // Merge our default shape with the display corners
+            val shape = baseShape.copy(
+                bottomStart = startRadius?.let { CornerSize(it) } ?: baseShape.bottomStart,
+                bottomEnd = endRadius?.let { CornerSize(it) } ?: baseShape.bottomEnd,
+            )
+            BoxShapeAndPadding(
+                shape = shape,
+                innerBottomPadding = maxOf(startRadius ?: 0.dp, endRadius ?: 0.dp),
+            )
+        } else {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/spundev/dynamicthemeexport/ui/export/ExportScreen.kt
+++ b/app/src/main/java/com/spundev/dynamicthemeexport/ui/export/ExportScreen.kt
@@ -6,13 +6,22 @@ import android.graphics.Typeface
 import android.os.Build
 import android.widget.Toast
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -21,6 +30,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -32,19 +43,27 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.toClipEntry
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.spundev.dynamicthemeexport.R
 import com.spundev.dynamicthemeexport.data.ColorFormat
 import com.spundev.dynamicthemeexport.data.ColorFormatSaver
 import com.spundev.dynamicthemeexport.data.ThemeColorPack
+import com.spundev.dynamicthemeexport.ui.theme.DynamicExportTheme
+import com.spundev.dynamicthemeexport.util.DisplayCorners
 import com.spundev.dynamicthemeexport.util.freeScroll.freeScroll
 import com.spundev.dynamicthemeexport.util.freeScroll.rememberFreeScrollState
+import com.spundev.dynamicthemeexport.util.rememberDisplayCorners
 import kotlinx.coroutines.launch
 
 @Composable
@@ -64,77 +83,104 @@ fun ExportScreen(
     val clipboard = LocalClipboard.current
     val scope = rememberCoroutineScope()
 
+    val displayCorners = rememberDisplayCorners()
+    ExportScreenContent(
+        colorFormat = colorFormat,
+        codeText = themeColorPackOutput,
+        onColorFormatChange = { colorFormat = it },
+        onCopy = {
+            scope.launch {
+                clipboard.setClipEntry(
+                    clipEntry = ClipData.newPlainText(
+                        /* label = */ themeColorPackOutput,
+                        /* text = */ themeColorPackOutput
+                    ).toClipEntry()
+                )
+                // Only show a toast for Android 12 (32) and lower.
+                if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+                    Toast.makeText(context, "Text copied", Toast.LENGTH_SHORT).show()
+                }
+            }
+        },
+        onShare = {
+            val sendIntent = Intent().apply {
+                action = Intent.ACTION_SEND
+                putExtra(Intent.EXTRA_TEXT, themeColorPackOutput)
+                type = "text/plain"
+            }
+            val shareIntent = Intent.createChooser(sendIntent, null)
+            context.startActivity(shareIntent)
+        },
+        displayCorners = displayCorners
+    )
+}
+
+@Composable
+private fun ExportScreenContent(
+    colorFormat: ColorFormat,
+    codeText: String,
+    onColorFormatChange: (ColorFormat) -> Unit,
+    onCopy: () -> Unit,
+    onShare: () -> Unit,
+    displayCorners: DisplayCorners,
+    windowInsets: WindowInsets = WindowInsets.safeDrawing,
+) {
+    val contentPadding = 8.dp
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp)
+        modifier = Modifier.padding(
+            top = contentPadding,
+            start = contentPadding,
+            end = contentPadding,
+        )
     ) {
-        // Copy and share icons
-        Row(modifier = Modifier.fillMaxWidth()) {
-            ColorFormatSelection(
-                colorFormat = colorFormat,
-                onColorFormatChange = { colorFormat = it }
-            )
-
-            Spacer(modifier = Modifier.weight(1f))
-
-            // Copy
-            FilledTonalIconButton(
-                onClick = {
-                    scope.launch {
-                        clipboard.setClipEntry(
-                            clipEntry = ClipData.newPlainText(
-                                /* label = */ themeColorPackOutput,
-                                /* text = */ themeColorPackOutput
-                            ).toClipEntry()
-                        )
-                        // Only show a toast for Android 12 (32) and lower.
-                        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
-                            Toast.makeText(context, "Text copied", Toast.LENGTH_SHORT).show()
-                        }
-                    }
-                }
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_content_copy_24),
-                    contentDescription = "Copy to clipboard"
-                )
-            }
-            // Share
-            FilledTonalIconButton(onClick = {
-                val sendIntent = Intent().apply {
-                    action = Intent.ACTION_SEND
-                    putExtra(Intent.EXTRA_TEXT, themeColorPackOutput)
-                    type = "text/plain"
-                }
-                val shareIntent = Intent.createChooser(sendIntent, null)
-                context.startActivity(shareIntent)
-            }) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_share_24),
-                    contentDescription = "Share"
-                )
-            }
-        }
-
-        // Text preview
-        Box(
+        ExportOptionsBar(
+            colorFormat = colorFormat,
+            onColorFormatChange = onColorFormatChange,
+            onCopy = onCopy,
+            onShare = onShare,
             modifier = Modifier
-                .fillMaxWidth()
-                .clip(MaterialTheme.shapes.small)
-                .background(MaterialTheme.colorScheme.secondaryContainer)
-                .freeScroll(rememberFreeScrollState())
-        ) {
-            SelectionContainer {
-                Text(
-                    text = themeColorPackOutput,
-                    style = MaterialTheme.typography.bodySmall.copy(
-                        color = MaterialTheme.colorScheme.onSecondaryContainer,
-                        fontFamily = FontFamily(Typeface.MONOSPACE)
-                    ),
-                    modifier = Modifier.padding(8.dp)
-                )
-            }
+        )
+        ExportCodeViewer(
+            codeText = codeText,
+            displayCorners = displayCorners,
+            // Let ExportCodeViewer handle the bottom value of our contentPadding
+            contentPadding = PaddingValues(bottom = contentPadding),
+            windowInsets = windowInsets.only(WindowInsetsSides.Bottom),
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}
+
+@Composable
+private fun ExportOptionsBar(
+    colorFormat: ColorFormat,
+    onColorFormatChange: (ColorFormat) -> Unit,
+    onCopy: () -> Unit,
+    onShare: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    // Copy and share icons
+    Row(modifier = modifier.fillMaxWidth()) {
+        ColorFormatSelection(
+            colorFormat = colorFormat,
+            onColorFormatChange = onColorFormatChange
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        // Copy
+        FilledTonalIconButton(onClick = onCopy) {
+            Icon(
+                painter = painterResource(R.drawable.ic_content_copy_24),
+                contentDescription = "Copy to clipboard"
+            )
+        }
+        // Share
+        FilledTonalIconButton(onClick = onShare) {
+            Icon(
+                painter = painterResource(R.drawable.ic_share_24),
+                contentDescription = "Share"
+            )
         }
     }
 }
@@ -142,11 +188,11 @@ fun ExportScreen(
 @Composable
 private fun ColorFormatSelection(
     colorFormat: ColorFormat,
-    onColorFormatChange: (ColorFormat) -> Unit
+    onColorFormatChange: (ColorFormat) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
-
-    Box(modifier = Modifier.wrapContentSize(Alignment.TopStart)) {
+    Box(modifier = modifier) {
         TextButton(onClick = { expanded = true }) {
             Text(text = "Change format")
         }
@@ -185,6 +231,280 @@ private fun ColorFormatSelection(
                     }
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun ExportCodeViewer(
+    codeText: String,
+    displayCorners: DisplayCorners,
+    windowInsets: WindowInsets,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues.Zero,
+) {
+    val fallbackShape = MaterialTheme.shapes.small
+    val displayAwareShape = rememberDisplayCornerAwareShape(
+        displayCorners = displayCorners,
+        contentPadding = contentPadding,
+        windowInsets = windowInsets,
+        baseShape = fallbackShape
+    )
+
+    // Make sure we always have a shape for our code viewer
+    val codeViewerShape = displayAwareShape ?: BoxShapeAndPadding(
+        shape = fallbackShape,
+        innerBottomPadding = 8.dp
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(contentPadding)
+            .windowInsetsPadding(windowInsets.only(WindowInsetsSides.Bottom))
+            .clip(codeViewerShape.shape)
+            .background(MaterialTheme.colorScheme.secondaryContainer)
+            .freeScroll(rememberFreeScrollState())
+    ) {
+        SelectionContainer {
+            Text(
+                text = codeText,
+                style = MaterialTheme.typography.bodySmall.copy(
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    fontFamily = FontFamily(Typeface.MONOSPACE)
+                ),
+                modifier = Modifier.padding(
+                    start = 8.dp,
+                    top = 8.dp,
+                    end = 8.dp,
+                    bottom = codeViewerShape.innerBottomPadding
+                )
+            )
+        }
+    }
+}
+
+
+@Preview
+@Composable
+private fun ExportScreenContentWithBottomInsetBiggerThanCornerRadiusPreview(
+    @PreviewParameter(LoremIpsum::class) text: String
+) {
+    val topStart = 0.dp
+    val topEnd = 0.dp
+    val bottomEnd = 48.dp
+    val bottomStart = 48.dp
+    val displayCorners = DisplayCorners(
+        topStart = topStart,
+        topEnd = topEnd,
+        bottomEnd = bottomEnd,
+        bottomStart = bottomStart,
+    )
+    val previewShape = RoundedCornerShape(
+        topStart = topStart,
+        topEnd = topEnd,
+        bottomEnd = bottomEnd,
+        bottomStart = bottomStart,
+    )
+
+    val windowInsets = WindowInsets(bottom = 96.dp)
+
+    // We don't need a ThemeColorPack for PreviewScreen.
+    // Get just the dynamic ColorScheme we need.
+    val context = LocalContext.current
+    val colorScheme = if (isSystemInDarkTheme()) {
+        dynamicDarkColorScheme(context)
+    } else {
+        dynamicLightColorScheme(context)
+    }
+
+    DynamicExportTheme(colorScheme = colorScheme) {
+        Box(
+            modifier = Modifier
+                .background(Color.Black)
+                .clip(previewShape)
+                .background(Color.White)
+        ) {
+            ExportScreenContent(
+                colorFormat = ColorFormat.SRGBInteger,
+                codeText = text.repeat(6),
+                onColorFormatChange = { },
+                onCopy = { },
+                onShare = { },
+                displayCorners = displayCorners,
+                windowInsets = windowInsets,
+            )
+
+            Spacer(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .windowInsetsBottomHeight(windowInsets)
+                    .background(Color.Gray)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ExportScreenContentWithBottomInsetSmallerThanCornerRadiusPreview(
+    @PreviewParameter(LoremIpsum::class) text: String
+) {
+    val topStart = 0.dp
+    val topEnd = 0.dp
+    val bottomEnd = 48.dp
+    val bottomStart = 48.dp
+    val displayCorners = DisplayCorners(
+        topStart = topStart,
+        topEnd = topEnd,
+        bottomEnd = bottomEnd,
+        bottomStart = bottomStart,
+    )
+    val previewShape = RoundedCornerShape(
+        topStart = topStart,
+        topEnd = topEnd,
+        bottomEnd = bottomEnd,
+        bottomStart = bottomStart,
+    )
+
+    val windowInsets = WindowInsets(bottom = 12.dp)
+
+    // We don't need a ThemeColorPack for PreviewScreen.
+    // Get just the dynamic ColorScheme we need.
+    val context = LocalContext.current
+    val colorScheme = if (isSystemInDarkTheme()) {
+        dynamicDarkColorScheme(context)
+    } else {
+        dynamicLightColorScheme(context)
+    }
+
+    DynamicExportTheme(colorScheme = colorScheme) {
+        Box(
+            modifier = Modifier
+                .background(Color.Black)
+                .clip(previewShape)
+                .background(Color.White)
+        ) {
+            ExportScreenContent(
+                colorFormat = ColorFormat.SRGBInteger,
+                codeText = text.repeat(6),
+                onColorFormatChange = { },
+                onCopy = { },
+                onShare = { },
+                displayCorners = displayCorners,
+                windowInsets = windowInsets
+            )
+
+            Spacer(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .windowInsetsBottomHeight(windowInsets)
+                    .background(Color.Gray)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ExportScreenContentWithBottomInsetSmallerThanCornerRadiusAndWeirdShapePreview(
+    @PreviewParameter(LoremIpsum::class) text: String
+) {
+    val topStart = 0.dp
+    val topEnd = 0.dp
+    val bottomEnd = 0.dp
+    val bottomStart = 92.dp
+    val displayCorners = DisplayCorners(
+        topStart = topStart,
+        topEnd = topEnd,
+        /* Use Unspecified instead of 0 to see if everything works */
+        bottomEnd = Dp.Unspecified,
+        bottomStart = bottomStart,
+    )
+    val previewShape = RoundedCornerShape(
+        topStart = topStart,
+        topEnd = topEnd,
+        bottomEnd = bottomEnd,
+        bottomStart = bottomStart,
+    )
+
+    val windowInsets = WindowInsets(bottom = 12.dp)
+
+    // We don't need a ThemeColorPack for PreviewScreen.
+    // Get just the dynamic ColorScheme we need.
+    val context = LocalContext.current
+    val colorScheme = if (isSystemInDarkTheme()) {
+        dynamicDarkColorScheme(context)
+    } else {
+        dynamicLightColorScheme(context)
+    }
+
+    DynamicExportTheme(colorScheme = colorScheme) {
+        Box(
+            modifier = Modifier
+                .background(Color.Black)
+                .clip(previewShape)
+                .background(Color.White)
+        ) {
+            ExportScreenContent(
+                colorFormat = ColorFormat.SRGBInteger,
+                codeText = text.repeat(6),
+                onColorFormatChange = { },
+                onCopy = { },
+                onShare = { },
+                displayCorners = displayCorners,
+                windowInsets = windowInsets
+            )
+
+            Spacer(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .windowInsetsBottomHeight(windowInsets)
+                    .background(Color.Gray)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ExportScreenContentWithUnspecifiedCornerRadiusPreview(
+    @PreviewParameter(LoremIpsum::class) text: String
+) {
+    val displayCorners = DisplayCorners.Unspecified
+    val windowInsets = WindowInsets(bottom = 48.dp)
+
+    // We don't need a ThemeColorPack for PreviewScreen.
+    // Get just the dynamic ColorScheme we need.
+    val context = LocalContext.current
+    val colorScheme = if (isSystemInDarkTheme()) {
+        dynamicDarkColorScheme(context)
+    } else {
+        dynamicLightColorScheme(context)
+    }
+
+    DynamicExportTheme(colorScheme = colorScheme) {
+        Box(modifier = Modifier.background(Color.White)) {
+            ExportScreenContent(
+                colorFormat = ColorFormat.SRGBInteger,
+                codeText = text.repeat(6),
+                onColorFormatChange = { },
+                onCopy = { },
+                onShare = { },
+                displayCorners = displayCorners,
+                windowInsets = windowInsets
+            )
+
+            Spacer(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .windowInsetsBottomHeight(windowInsets)
+                    .background(Color.Gray)
+            )
         }
     }
 }

--- a/app/src/main/java/com/spundev/dynamicthemeexport/ui/preview/PreviewGridScreen.kt
+++ b/app/src/main/java/com/spundev/dynamicthemeexport/ui/preview/PreviewGridScreen.kt
@@ -16,10 +16,15 @@ import androidx.compose.foundation.layout.Grid
 import androidx.compose.foundation.layout.GridTrackSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -82,6 +87,10 @@ fun PreviewGridScreen() {
         }
     }
 
+    val gridInsets = WindowInsets.safeDrawing.only(
+        WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+    )
+
     Grid(
         config = {
             // Split
@@ -114,6 +123,7 @@ fun PreviewGridScreen() {
                 scaleX = zoom
                 scaleY = zoom
             }
+            .windowInsetsPadding(gridInsets)
             .padding(16.dp)
     ) {
         PrimarySecondaryTertiarySection(

--- a/app/src/main/java/com/spundev/dynamicthemeexport/ui/preview/PreviewScreen.kt
+++ b/app/src/main/java/com/spundev/dynamicthemeexport/ui/preview/PreviewScreen.kt
@@ -12,11 +12,16 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.dynamicDarkColorScheme
@@ -65,6 +70,10 @@ fun ColorRolesTable() {
         currentColorScheme.getElevatedSurfaceLevels()
     }
 
+    val tableInsets = WindowInsets.safeDrawing.only(
+        WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+    )
+
     var zoom: Float by remember { mutableFloatStateOf(1f) }
     val freeScrollState = rememberFreeScrollState()
     Column(
@@ -94,6 +103,7 @@ fun ColorRolesTable() {
                 scaleX = zoom
                 scaleY = zoom
             }
+            .windowInsetsPadding(tableInsets)
             .padding(16.dp)
     ) {
         // Copy to clipboard

--- a/app/src/main/java/com/spundev/dynamicthemeexport/util/DisplayCorners.kt
+++ b/app/src/main/java/com/spundev/dynamicthemeexport/util/DisplayCorners.kt
@@ -1,0 +1,124 @@
+package com.spundev.dynamicthemeexport.util
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.core.view.RoundedCornerCompat
+import androidx.core.view.RoundedCornerCompat.POSITION_BOTTOM_LEFT
+import androidx.core.view.RoundedCornerCompat.POSITION_BOTTOM_RIGHT
+import androidx.core.view.RoundedCornerCompat.POSITION_TOP_LEFT
+import androidx.core.view.RoundedCornerCompat.POSITION_TOP_RIGHT
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+/**
+ * Create a DisplayCorners state.
+ *
+ * NOTE: Custom implementation until b/401464090 is fixed.
+ */
+@Composable
+fun rememberDisplayCorners(): DisplayCorners {
+    val view = LocalView.current
+    val density: Density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
+
+    // NOTE: We need WindowInsetsCompat to query the display corner radius. The "RootWindowInsets"
+    //  we get from ViewCompat is a nullable value that can also change over time.
+    //  WindowInsetsCompat has a setOnApplyWindowInsetsListener that would be perfect for this, but
+    //  apparently it would replace any listener already set on this view. This might only be a
+    //  problem if more than one rememberDisplayCorners is used at the same time, but we don't
+    //  really know if it could cause unexpected issues outside this function.
+    //  Since the worst that can happen is that we get Unspecified values in our DisplayCorners, we'd
+    //  rather risk getting wrong corner values than cause issues elsewhere.
+
+    // Trigger recomposition on physical screen changes (rotation, foldables, etc.)
+    // These are the events we can think of where corner values could change.
+    val configuration = LocalConfiguration.current
+
+    // Use WindowInsets from Compose as a way to make sure the root insets have been dispatched by
+    // the time we read them. This top inset gives us a value that changes once real insets arrive,
+    // so we use it as an "insets are ready" flag.
+    val topInset = WindowInsets.systemBars.getTop(density)
+
+    return remember(view, density, layoutDirection, configuration, topInset) {
+        val insets = ViewCompat.getRootWindowInsets(view)
+        insets?.getDisplayCorners(density, layoutDirection) ?: DisplayCorners.Unspecified
+    }
+}
+
+/**
+ * State holder for the display corner radius state.
+ */
+data class DisplayCorners(
+    val topStart: Dp,
+    val topEnd: Dp,
+    val bottomEnd: Dp,
+    val bottomStart: Dp,
+) {
+    companion object {
+        val Unspecified = DisplayCorners(
+            topStart = Dp.Unspecified,
+            topEnd = Dp.Unspecified,
+            bottomEnd = Dp.Unspecified,
+            bottomStart = Dp.Unspecified
+        )
+
+        val Zero = DisplayCorners(
+            topStart = 0.dp,
+            topEnd = 0.dp,
+            bottomEnd = 0.dp,
+            bottomStart = 0.dp
+        )
+    }
+}
+
+/**
+ * Get the corner radius [Dp] for a [position] using [WindowInsetsCompat]
+ */
+private fun WindowInsetsCompat.getCornerRadiusDp(
+    @RoundedCornerCompat.Position position: Int,
+    density: Density
+): Dp? {
+    val radiusPx = getRoundedCorner(position)?.radius
+    return with(density) { radiusPx?.toDp() }
+}
+
+/**
+ * Get a [DisplayCorners] by querying all [RoundedCornerCompat.Position].
+ *
+ * NOTE: Left and right positions are converted to start and end using the current [LayoutDirection].
+ */
+private fun WindowInsetsCompat.getDisplayCorners(
+    density: Density,
+    layoutDirection: LayoutDirection
+): DisplayCorners {
+    val topLeft = getCornerRadiusDp(POSITION_TOP_LEFT, density) ?: Dp.Unspecified
+    val topRight = getCornerRadiusDp(POSITION_TOP_RIGHT, density) ?: Dp.Unspecified
+    val bottomRight = getCornerRadiusDp(POSITION_BOTTOM_RIGHT, density) ?: Dp.Unspecified
+    val bottomLeft = getCornerRadiusDp(POSITION_BOTTOM_LEFT, density) ?: Dp.Unspecified
+
+    return if (layoutDirection == LayoutDirection.Ltr) {
+        DisplayCorners(
+            topStart = topLeft,
+            topEnd = topRight,
+            bottomEnd = bottomRight,
+            bottomStart = bottomLeft,
+        )
+    } else {
+        DisplayCorners(
+            topStart = topRight,
+            topEnd = topLeft,
+            bottomEnd = bottomLeft,
+            bottomStart = bottomRight,
+        )
+    }
+}


### PR DESCRIPTION
Until now, our `MainScreen` composable was in charge of adding the necessary space to avoid the `systemBars`. This was good enough to avoid drawing behind the system UI, but none of our screens made use of the available space.

With this changes, each screen is now in charge of avoiding the system UI.
- Our colors table now draws behind the navigation bar and uses insets to make sure that all content is visible.
- Our export screen now  uses insets to avoid getting cut by the device's display corners.